### PR TITLE
add retry on verify old login 

### DIFF
--- a/tasks/system/Linux.yml
+++ b/tasks/system/Linux.yml
@@ -237,6 +237,8 @@
       - 200
       - 401
   register: login_result
+  retries: 3
+  delay: 20
   when:
     - change_password | bool
 


### PR DESCRIPTION
# Pull Request Template

## Description
in case of startup not finish after dabase upgrade, a retry on this task can resolve the issue.
[Fixes # (issue)](https://github.com/lean-delivery/ansible-role-sonarqube/issues/5259)

## Type of change
Bug fix
