### PR TITLE
refactor: consolidate duplicate restart handlers

### DIFF
--- a/tasks/system/Linux.yml
+++ b/tasks/system/Linux.yml
@@ -104,9 +104,7 @@
       group: '{{ sonar_group }}'
       remote_src: true
       creates: '{{ sonar_installation }}/conf/wrapper.conf'
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: Render sonar.properties
     ansible.builtin.template:
@@ -114,9 +112,7 @@
       dest: '{{ sonar_installation }}/conf/sonar.properties'
       mode: 0400
       owner: '{{ sonar_user }}'
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: Render sonarqube.service
     ansible.builtin.template:
@@ -124,9 +120,7 @@
       dest: /etc/systemd/system/sonarqube.service
       mode: 0444
       owner: '{{ sonar_user }}'
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: Make sure template destination directory exists
     ansible.builtin.file:
@@ -164,9 +158,7 @@
     retries: 3
     delay: 5
     loop: '{{ sonar_all_plugins_with_exclusions }}'
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: Copy branch plugin
     ansible.builtin.copy:
@@ -178,9 +170,7 @@
       - branch_plugin_url in sonar_all_plugins
       - branch_pversion is version("1.2.0", ">=")
       - branch_pversion is version("1.7.0", "<=")
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: 'Download web app'
     ansible.builtin.get_url:
@@ -208,9 +198,7 @@
     when:
       - branch_plugin_url in sonar_all_plugins
       - branch_pversion is version("1.24.0", ">=")
-    notify:
-      - Restart Sonarqube
-      - Restart Sonarqube with script
+    notify: "{{ 'Restart Sonarqube' if sonar_start_by_service | bool else 'Restart Sonarqube with script' }}"
 
   - name: Flush handlers
     ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Merge the two mutually-exclusive "Restart Sonarqube" and "Restart Sonarqube with script" handlers into a single handler with conditional logic. This eliminates wasteful dual notifications and clarifies that only one restart method will execute based on sonar_start_by_service.

- Consolidate handlers in handlers/main.yml using block with conditional tasks
- Update all notify statements in tasks/system/Linux.yml to reference single handler

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Reviews

Please identify developer to review this change

- [ ] @developer

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
